### PR TITLE
Fix BlockCheckboxInput missing lodash import

### DIFF
--- a/src/components/blockParts/BlockCheckboxInput.jsx
+++ b/src/components/blockParts/BlockCheckboxInput.jsx
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { useTrackedState, useUpdate } from '../StateProvider';
 
 export default function BlockCheckboxInput({ dataPath, path, tooltip }) {


### PR DESCRIPTION
## Summary
- fix missing lodash import in BlockCheckboxInput

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68403c8f97ec832f97317a360db4a408